### PR TITLE
Integrate property compiler into graph compiler

### DIFF
--- a/compiler/__init__.py
+++ b/compiler/__init__.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
-compiler_base_dir = Path(__file__).parent
+root_base_dir = Path(__file__).parent.parent
+compiler_base_dir = os.path.join(root_base_dir, "compiler")
 graph_base_dir = os.path.join(compiler_base_dir, "graph")
 ir_base_dir = os.path.join(compiler_base_dir, "ir")

--- a/compiler/graph/backend/mrpc.py
+++ b/compiler/graph/backend/mrpc.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import tomli
 import tomli_w
 
-from compiler.graph import graph_base_dir
+from compiler import graph_base_dir
 from compiler.graph.backend.utils import copy_remote_container, execute_remote_container
 from compiler.graph.ir import GraphIR
 from compiler.graph.ir.element import AbsElement

--- a/compiler/graph/ir/element.py
+++ b/compiler/graph/ir/element.py
@@ -5,8 +5,9 @@ from typing import Any, Dict, List
 
 import yaml
 
-from compiler.graph import adn_base_dir
+from compiler import compiler_base_dir
 from compiler.graph.pseudo_element_compiler import pseudo_gen_property
+from compiler.ir import compile_element_property
 
 global_element_id = 0
 
@@ -52,31 +53,18 @@ class AbsElement:
         Args:
             pseudo: If true, call the pseudo element compiler to generate properties.
         """
-        if pseudo:
-            self.property = pseudo_gen_property(self)
-        else:
-            self.property: Dict[str, Dict[str, Any]] = {
-                "request": dict(),
-                "response": dict(),
-            }
-            # TODO: call element compiler to generate properties
-        if pseudo:
-            # read handwritten properties
-            for spec in self.spec:
-                filename = spec.split("/")[-1].replace("sql", "yaml")
-                with open(
-                    os.path.join(adn_base_dir, "elements/property", filename), "r"
-                ) as f:
-                    current_dict = yaml.safe_load(f)
-                for t in ["request", "response"]:
-                    if current_dict[t] is not None:
-                        for p, value in current_dict[t].items():
-                            if p not in self.property[t]:
-                                self.property[t][p] = value
-                            elif type(value) == list:
-                                self.property[t][p].extend(value)
-        else:
-            pass
+        self.property = compile_element_property(self.lib_name)
+        # if pseudo:
+        #     self.property = pseudo_gen_property(self)
+        # else:
+        #     # self.property: Dict[str, Dict[str, Any]] = {
+        #     #     "request": dict(),
+        #     #     "response": dict(),
+        #     # }
+        #     self.property = compile_element_property(self.lib_name)
+        #     print(self.property)
+        #     assert 0
+        #     # TODO: call element compiler to generate properties
 
     def fuse(self, other: AbsElement):
         """Fuse another element in

--- a/compiler/graph/pseudo_element_compiler.py
+++ b/compiler/graph/pseudo_element_compiler.py
@@ -12,7 +12,7 @@ from typing import Any, Dict
 
 import yaml
 
-from compiler.graph import adn_base_dir
+from compiler import compiler_base_dir
 
 support_list = ["logging", "qos", "null", "ratelimit", "hotel-acl"]
 
@@ -29,7 +29,7 @@ def pseudo_gen_property(element) -> Dict[str, Dict[str, Any]]:
     property = {"request": dict(), "response": dict()}
     for spec in element.spec:
         filename = spec.split("/")[-1].replace("sql", "yaml")
-        property_file = os.path.join(adn_base_dir, "elements/property", filename)
+        property_file = os.path.join(compiler_base_dir, "elements/property", filename)
         assert os.path.isfile(property_file), f"property file for {spec} not exist"
         with open(property_file, "r") as f:
             current_dict = yaml.safe_load(f)

--- a/compiler/ir/__init__.py
+++ b/compiler/ir/__init__.py
@@ -1,0 +1,37 @@
+import os
+from typing import Dict
+
+from compiler import root_base_dir
+from compiler.ir.frontend import IRCompiler, Printer
+from compiler.ir.props.flow import FlowGraph
+
+
+def compile_element_property(engine_name: str, verbose: bool = False) -> Dict:
+    compiler = IRCompiler()
+    printer = Printer()
+
+    with open(os.path.join(root_base_dir, f"elements/ir/{engine_name}.adn")) as f:
+        spec = f.read()
+        ir = compiler.compile(spec)
+        p = ir.accept(printer, None)
+        if verbose:
+            print(p)
+
+        req = FlowGraph().analyze(ir.req, verbose)
+        resp = FlowGraph().analyze(ir.resp, verbose)
+
+        yaml = "request:\n" + req.to_yaml() + "response:\n" + resp.to_yaml()
+        if verbose:
+            print(yaml)
+        return {
+            "request": {
+                "read": req.read,
+                "write": req.write,
+                "drop": req.drop,
+            },
+            "response": {
+                "read": resp.read,
+                "write": resp.write,
+                "drop": resp.drop,
+            },
+        }

--- a/compiler/ir/visitor.py
+++ b/compiler/ir/visitor.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Callable, List, Protocol, Sequence, TypeVar
 
-from ir.node import *
+from compiler.ir.node import *
 
 
 def accept(visitor: Visitor, ctx) -> Callable:

--- a/compiler/ir_main.py
+++ b/compiler/ir_main.py
@@ -10,11 +10,11 @@ from compiler.ir.frontend import IRCompiler, Printer
 from compiler.ir.props.flow import FlowGraph
 
 
-def compile_element(name: str, verbose: bool = False) -> Dict:
+def compile_element(engine_name: str, verbose: bool = False) -> Dict:
     compiler = IRCompiler()
     printer = Printer()
 
-    with open(f"../elements/ir/{engine}.adn") as f:
+    with open(f"../elements/ir/{engine_name}.adn") as f:
         spec = f.read()
         ir = compiler.compile(spec)
         p = ir.accept(printer, None)

--- a/compiler/main.py
+++ b/compiler/main.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 
-from compiler.graph import graph_base_dir
+from compiler import graph_base_dir
 from compiler.graph.backend import scriptgen
 from compiler.graph.frontend import GCParser
 from compiler.graph.logger import IR_LOG, init_logging

--- a/elements/ir/hotel-acl.adn
+++ b/elements/ir/hotel-acl.adn
@@ -1,0 +1,24 @@
+internal
+{
+	acl: Map<string, string>
+}
+
+fn init() {
+    acl.set('danyang', 'Yes');
+}
+
+fn req(rpc_req) {
+	match (acl.get(rpc_req.get('customer_name')) == 'Yes') {
+		True => {
+			send(rpc_req, NET);
+		}
+		// default includes none or “no”
+		False => {
+			send(err('acl'), APP);
+		}
+	}; 
+}
+
+fn resp(rpc_resp) {
+    send(rpc_resp, APP);	
+}

--- a/elements/ir/logging.adn
+++ b/elements/ir/logging.adn
@@ -12,6 +12,6 @@ fn req(rpc_req) {
 }
 
 fn resp(rpc_resp) {
-	log.get(log.size(), rpc_resp.get('payload'));
+	log.set(log.size(), rpc_resp.get('payload'));
 	send(rpc_resp, APP);
 }


### PR DESCRIPTION
@livingshade Some minor changes in the element compiler include
* Fix bugs in `elements/ir/logging.adn` and `compiler/ir_main.py`
* Copy the `compile_element()` API into `compiler/ir/__init__.py` and rename it as `compile_element_property()`.
We could defer merging this PR until Xiangfeng confirms that there's no problem running the original graph compiler.