### PR TITLE
fix metrics bug

### DIFF
--- a/compiler/element/backend/rustgen.py
+++ b/compiler/element/backend/rustgen.py
@@ -115,6 +115,8 @@ class RustContext:
                 return RustGlobalFunctions["min_f64"]
             case "time_diff":
                 return RustGlobalFunctions["time_diff"]
+            case "time_diff_ref":
+                return RustGlobalFunctions["time_diff_ref"]
             case "encrypt":
                 return RustGlobalFunctions["encrypt"]
             case "decrypt":
@@ -343,6 +345,8 @@ class RustGenerator(Visitor):
         for idx, ty in enumerate(types):
             if ty.name == "&str":
                 args[idx] = f"&{args[idx]}"
+            elif ty.name == "Instant":
+                args[idx] = f"{args[idx]}.clone()"
             else:
                 args[idx] = f"({args[idx]} as {ty.name})"
         ret = fn.gen_call(args)

--- a/examples/match_action/metrics.adn
+++ b/examples/match_action/metrics.adn
@@ -14,6 +14,13 @@ fn req(rpc_req) {
 
 fn resp(rpc_resp) {
   rpc_name := rpc_resp.get('name');
-  lat := time_diff(current_time(), record.get(rpc_name));
-  latency.set(latency.size(), lat);
+  match(record.get(rpc_name)) {
+    Some(t) => {
+      lat := time_diff(current_time(), t);
+      latency.set(latency.size(), lat);
+    }
+    None => {
+    }
+  };
+  send(rpc_resp, APP);
 }


### PR DESCRIPTION
This fix #29 as well as #28 
Metrics has two bugs:
- Lacks match for `Some` and `None` to container `get` so it won't compiler
- Lacks `send(rpc_resp, APP)` so it won't send any response
