### PR TITLE
Add bandwidth limit and circuit breaker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# vscode 
+.vscode/* 

--- a/examples/match_action/bandwidthlimit.adn
+++ b/examples/match_action/bandwidthlimit.adn
@@ -1,0 +1,32 @@
+internal {
+	last: Instant
+	limit: float
+	token: float
+	per_sec: float
+}
+
+fn init() {
+	last := current_time();
+	limit := 50.0;
+	token := 5.0;
+	per_sec := 5.0;
+}
+
+fn req(rpc_req) {
+	token := min(limit, token + (per_sec * time_diff(current_time(), last)));
+	last := current_time();
+    size := rpc_req.len()
+    match (token >= size) {
+		true => {
+			token := token - size;
+			send(rpc_req, NET);
+        }
+		false => {
+			send(err('ratelimit'), APP);
+		}
+	};
+}
+
+fn resp(rpc_resp) {
+    send(rpc_resp, APP);
+}

--- a/examples/match_action/circuit_breaker.adn
+++ b/examples/match_action/circuit_breaker.adn
@@ -1,0 +1,28 @@
+internal {
+	max_concurrent_req: int
+    pending_req: int
+    drop_count: int
+}
+fn init(max_concurrent_req) {
+	max_concurrent_req := 10;
+    pending_req := 0;
+    drop_count := 0;
+}
+
+fn req(rpc_req) {
+	match(pending_req <= max_concurrent_req) {
+		true => {
+            pending_req := pending_req + 1;
+			send(rpc_req, NET);
+		}
+		false => {
+            drop_count := drop_count + 1;
+			send(err('circuit breaker'), APP);
+		}
+	};
+}
+
+fn resp(rpc_resp) {
+    pending_req := pending_req - 1;
+    send(rpc_resp, APP);
+}


### PR DESCRIPTION
Adding two new elements:

- Bandwidth limit: similar to rate limit. Except we limit the size of the request instead of the count. Reference: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/bandwidth_limit_filter#config-http-filters-bandwidth-limit
- Circuit breaker: this is a simplified circuit breaker that limits the number of concurrent requests. We might want to add a logic that starts dropping requests after x consecutive failures. See: https://istio.io/latest/docs/tasks/traffic-management/circuit-breaking/

#39 