### PR TITLE
Add State Decorators & Element compiler takes proto/method name as input

### DIFF
--- a/compiler/element/__init__.py
+++ b/compiler/element/__init__.py
@@ -111,7 +111,7 @@ def compile_element_property(element_names: List[str], verbose: bool = False) ->
     # Initialize a tuple of Property objects to hold request and response properties
     LOG.info("Analyzing element properties")
     ret = (Property(), Property())
-    
+
     # Default properties
     stateful = False
     consistency = None
@@ -154,12 +154,11 @@ def compile_element_property(element_names: List[str], verbose: bool = False) ->
             ret[1].check()
 
             stateful = stateful or len(ir.definition.internal) > 0
-            
+
             # TODO(XZ): might want want to check for individual state variable. (incl. conflict requirements)
             consistency = ir.definition.internal[0][2].name
             combiner = ir.definition.internal[0][3].name
             persistence = ir.definition.internal[0][4].name
-
 
     ret[0].check()
     ret[1].check()
@@ -175,7 +174,7 @@ def compile_element_property(element_names: List[str], verbose: bool = False) ->
             "stateful": stateful,
             "consistency": consistency,
             "combiner": combiner,
-            "persistence": persistence
+            "persistence": persistence,
         },
         "request": {
             "record" if record else "read": ret[0].read,

--- a/compiler/element/__init__.py
+++ b/compiler/element/__init__.py
@@ -111,7 +111,12 @@ def compile_element_property(element_names: List[str], verbose: bool = False) ->
     # Initialize a tuple of Property objects to hold request and response properties
     LOG.info("Analyzing element properties")
     ret = (Property(), Property())
+    
+    # Default properties
     stateful = False
+    consistency = None
+    combiner = "LWW"
+    persistence = "ephemeral"
 
     for element_name in element_names:
         LOG.info(f"(Property Analyzer) Parsing {element_name}")
@@ -149,6 +154,12 @@ def compile_element_property(element_names: List[str], verbose: bool = False) ->
             ret[1].check()
 
             stateful = stateful or len(ir.definition.internal) > 0
+            
+            # TODO(XZ): might want want to check for individual state variable. (incl. conflict requirements)
+            consistency = ir.definition.internal[0][2].name
+            combiner = ir.definition.internal[0][3].name
+            persistence = ir.definition.internal[0][4].name
+
 
     ret[0].check()
     ret[1].check()
@@ -160,7 +171,12 @@ def compile_element_property(element_names: List[str], verbose: bool = False) ->
     )
 
     return {
-        "stateful": stateful,
+        "state": {
+            "stateful": stateful,
+            "consistency": consistency,
+            "combiner": combiner,
+            "persistence": persistence
+        },
         "request": {
             "record" if record else "read": ret[0].read,
             "write": ret[0].write,

--- a/compiler/element/__init__.py
+++ b/compiler/element/__init__.py
@@ -50,8 +50,10 @@ def gen_code(
     elif backend_name == "envoy":
         generator = WasmGenerator(placement)
         finalize = WasmFinalize
-        # TODO(XZ): We assume there will be only one method being used in an element. 
-        ctx = WasmContext(proto=proto_path.replace(".proto", ""), method_name=method_name)
+        # TODO(XZ): We assume there will be only one method being used in an element.
+        ctx = WasmContext(
+            proto=proto_path.replace(".proto", ""), method_name=method_name
+        )
 
     printer = Printer()
 
@@ -83,7 +85,7 @@ def gen_code(
 
     LOG.info(f"Generating {backend_name} code")
     consolidated.accept(generator, ctx)
-    
+
     finalize(output_name, ctx, output_dir, placement, proto_path)
 
 

--- a/compiler/element/__init__.py
+++ b/compiler/element/__init__.py
@@ -18,6 +18,8 @@ def gen_code(
     output_dir: str,
     backend_name: str,
     placement: str,
+    proto_path: str,
+    method_name: str,
     verbose: bool = False,
 ) -> str:
     """
@@ -43,11 +45,13 @@ def gen_code(
     if backend_name == "mrpc":
         generator = RustGenerator(placement)
         finalize = RustFinalize
+        # TODO(XZ): Add configurable proto for mRPC codegen
         ctx = RustContext()
     elif backend_name == "envoy":
         generator = WasmGenerator(placement)
         finalize = WasmFinalize
-        ctx = WasmContext()
+        # TODO(XZ): We assume there will be only one method being used in an element. 
+        ctx = WasmContext(proto=proto_path.replace(".proto", ""), method_name=method_name)
 
     printer = Printer()
 
@@ -79,8 +83,8 @@ def gen_code(
 
     LOG.info(f"Generating {backend_name} code")
     consolidated.accept(generator, ctx)
-
-    finalize(output_name, ctx, output_dir, placement)
+    
+    finalize(output_name, ctx, output_dir, placement, proto_path)
 
 
 def compile_element_property(element_names: List[str], verbose: bool = False) -> Dict:

--- a/compiler/element/backend/envoy/finalizer.py
+++ b/compiler/element/backend/envoy/finalizer.py
@@ -26,7 +26,7 @@ def retrieve(ctx: WasmContext, name: str) -> Dict:
     }
 
 
-def gen_template(_placement, output_dir, snippet, lib_name):
+def gen_template(_placement, output_dir, snippet, lib_name, proto_path):
     os.system(f"rm -rf {output_dir}")
     os.system(f"mkdir -p {output_dir}")
     os.system(f"mkdir -p {output_dir}/src")
@@ -39,7 +39,15 @@ def gen_template(_placement, output_dir, snippet, lib_name):
         f.write(build_sh.format(**snippet))
 
     template_path = os.path.join(COMPILER_ROOT, "element/backend/envoy/templates")
-    os.system(f"cp {template_path}/build.rs {output_dir}")
+    
+    # Add the proto file to the generated code
+    with open(f"{template_path}/build.rs", 'r') as file:
+        build_file = file.read()
+    build_file = build_file.replace("PROTO_FILENAME", proto_path)
+    with open(f"{output_dir}/build.rs ", 'w') as file:
+        file.write(build_file)
+    
+    # TODO(XZ): copy the real proto files.
     os.system(f"cp {template_path}/ping.proto {output_dir}")
     os.system(f"cp {template_path}/pong.proto {output_dir}")
     os.system(f"cp {template_path}/rust-toolchain.toml {output_dir}")
@@ -51,6 +59,6 @@ def gen_template(_placement, output_dir, snippet, lib_name):
     )
 
 
-def finalize(name: str, ctx: WasmContext, output_dir: str, placement: str):
+def finalize(name: str, ctx: WasmContext, output_dir: str, placement: str, proto_path: str):
     snippet = retrieve(ctx, name)
-    gen_template(placement, output_dir, snippet, name)
+    gen_template(placement, output_dir, snippet, name, proto_path)

--- a/compiler/element/backend/envoy/finalizer.py
+++ b/compiler/element/backend/envoy/finalizer.py
@@ -39,14 +39,14 @@ def gen_template(_placement, output_dir, snippet, lib_name, proto_path):
         f.write(build_sh.format(**snippet))
 
     template_path = os.path.join(COMPILER_ROOT, "element/backend/envoy/templates")
-    
+
     # Add the proto file to the generated code
-    with open(f"{template_path}/build.rs", 'r') as file:
+    with open(f"{template_path}/build.rs", "r") as file:
         build_file = file.read()
     build_file = build_file.replace("PROTO_FILENAME", proto_path)
-    with open(f"{output_dir}/build.rs ", 'w') as file:
+    with open(f"{output_dir}/build.rs ", "w") as file:
         file.write(build_file)
-    
+
     # TODO(XZ): copy the real proto files.
     os.system(f"cp {template_path}/ping.proto {output_dir}")
     os.system(f"cp {template_path}/pong.proto {output_dir}")
@@ -59,6 +59,8 @@ def gen_template(_placement, output_dir, snippet, lib_name, proto_path):
     )
 
 
-def finalize(name: str, ctx: WasmContext, output_dir: str, placement: str, proto_path: str):
+def finalize(
+    name: str, ctx: WasmContext, output_dir: str, placement: str, proto_path: str
+):
     snippet = retrieve(ctx, name)
     gen_template(placement, output_dir, snippet, name, proto_path)

--- a/compiler/element/backend/envoy/templates/build.rs
+++ b/compiler/element/backend/envoy/templates/build.rs
@@ -1,5 +1,5 @@
 // Specify the location of proto files here
-const PROTO: &str = "./ping.proto";
+const PROTO: &str = "./PROTO_FILENAME";
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed={PROTO}");
     prost_build::compile_protos(&[PROTO], &["."])?;

--- a/compiler/element/backend/envoy/wasmgen.py
+++ b/compiler/element/backend/envoy/wasmgen.py
@@ -123,7 +123,7 @@ class WasmContext:
 class WasmGenerator(Visitor):
     def __init__(self, placement: str) -> None:
         self.placement = placement
-        if placement != "Client" and placement != "Server":
+        if placement != "client" and placement != "server":
             raise Exception("placement should be sender or receiver")
 
     def visitNode(self, node: Node, ctx: WasmContext):
@@ -139,7 +139,8 @@ class WasmGenerator(Visitor):
         node.resp.accept(self, ctx)
 
     def visitInternal(self, node: Internal, ctx: WasmContext) -> None:
-        for i, t in node.internal:
+        # TODO(xz): Add logic to handle decorators
+        for (i, t, cons, comb, per) in node.internal:
             name = i.name
             wasm_type = t.accept(self, ctx)
             ctx.declare(name, wasm_type, False, True)

--- a/compiler/element/backend/mrpc/finalizer.py
+++ b/compiler/element/backend/mrpc/finalizer.py
@@ -169,7 +169,6 @@ def finalize(
     template_name_first_cap = name
     template_name_all_cap = name
 
-
     info = retrieve_info(ctx)
     gen_template(
         placement,

--- a/compiler/element/backend/mrpc/finalizer.py
+++ b/compiler/element/backend/mrpc/finalizer.py
@@ -161,7 +161,9 @@ def gen_template(
     )
 
 
-def finalize(name: str, ctx: RustContext, output_dir: str, placement: str, proto_path: str):
+def finalize(
+    name: str, ctx: RustContext, output_dir: str, placement: str, proto_path: str
+):
     name = name
     if name == "logging":
         template_name = "logging"

--- a/compiler/element/backend/mrpc/finalizer.py
+++ b/compiler/element/backend/mrpc/finalizer.py
@@ -161,7 +161,7 @@ def gen_template(
     )
 
 
-def finalize(name: str, ctx: RustContext, output_dir: str, placement: str):
+def finalize(name: str, ctx: RustContext, output_dir: str, placement: str, proto_path: str):
     name = name
     if name == "logging":
         template_name = "logging"

--- a/compiler/element/backend/mrpc/rustgen.py
+++ b/compiler/element/backend/mrpc/rustgen.py
@@ -178,7 +178,7 @@ class RustGenerator(Visitor):
         node.resp.accept(self, ctx)
 
     def visitInternal(self, node: Internal, ctx: RustContext) -> None:
-        for (i, t) in node.internal:
+        for (i, t, cons, comb, per) in node.internal:
             name = i.name
             rust_type = t.accept(self, ctx)
             ctx.declare(name, rust_type, False)

--- a/compiler/element/frontend/adn.lark
+++ b/compiler/element/frontend/adn.lark
@@ -2,7 +2,11 @@ start: definition procedure procedure procedure
 
 definition: "internal" "{" declaration* "}"
 
-declaration: identifier ":" type_
+declaration: (consistency_decorator | combiner_decorator | persistence_decorator)* identifier ":" type_
+
+consistency_decorator: "@consistency" "(" CNAME ")"
+combiner_decorator: "@combiner" "(" CNAME ")"
+persistence_decorator: "@persistence" "(" CNAME ")"
 
 identifier: CNAME
 

--- a/compiler/element/frontend/printer.py
+++ b/compiler/element/frontend/printer.py
@@ -18,8 +18,14 @@ class Printer(Visitor):
 
     def visitInternal(self, node: Internal, ctx):
         ret = "Internal:\n"
-        for (i, t) in node.internal:
-            ret += f"{i.accept(self, ctx)}: {t.accept(self, ctx)}\n"
+        for (i, t, cons, comb, per) in node.internal:
+            i_val = i.accept(self, ctx)
+            t_val = t.accept(self, ctx)
+            cons_val = cons.accept(self, ctx)
+            comb_val = comb.accept(self, ctx)
+            per_val = per.accept(self, ctx)
+
+            ret += f"{i_val}: {t_val} {cons_val} {comb_val} {per_val}\n"
         return ret + "\n"
 
     def visitProcedure(self, node: Procedure, ctx):
@@ -61,6 +67,15 @@ class Printer(Visitor):
         )
 
     def visitIdentifier(self, node: Identifier, ctx):
+        return node.name
+
+    def visitConsistencyDecorator(self, node: ConsistencyDecorator, ctx):
+        return node.name
+    
+    def visitCombinerDecorator(self, node: CombinerDecorator, ctx):
+        return node.name
+    
+    def visitPersistenceDecorator(self, node: PersistenceDecorator, ctx):
         return node.name
 
     def visitType(self, node: Type, ctx):

--- a/compiler/element/frontend/printer.py
+++ b/compiler/element/frontend/printer.py
@@ -71,10 +71,10 @@ class Printer(Visitor):
 
     def visitConsistencyDecorator(self, node: ConsistencyDecorator, ctx):
         return node.name
-    
+
     def visitCombinerDecorator(self, node: CombinerDecorator, ctx):
         return node.name
-    
+
     def visitPersistenceDecorator(self, node: PersistenceDecorator, ctx):
         return node.name
 

--- a/compiler/element/frontend/transformer.py
+++ b/compiler/element/frontend/transformer.py
@@ -1,6 +1,7 @@
 from lark import Transformer
 
 from compiler.element.node import *
+from compiler.element.frontend.util import *
 
 
 class IRTransformer(Transformer):
@@ -14,8 +15,46 @@ class IRTransformer(Transformer):
     def definition(self, d) -> Internal:
         return Internal(d)
 
-    def declaration(self, d) -> Tuple[Identifier, Type]:
-        return (d[0], d[1])
+    def declaration(self, d) -> Tuple[Identifier, Type, ConsistencyDecorator, CombinerDecorator, PersistenceDecorator]:
+        """
+        Processes a list to create a declaration tuple consisting of an Identifier, Type, and optional decorators.
+
+        Parameters:
+        d : list
+            A list containing an Identifier, Type, and optional decorator instances.
+
+        Returns:
+        Tuple[Identifier, Type, ConsistencyDecorator, CombinerDecorator, PersistenceDecorator]
+            A tuple containing the Identifier, Type, and instances of the optional decorators.
+        """
+        result = [d[-2], d[-1]]
+        
+        # Define the list of decorator types
+        decorators = [ConsistencyDecorator, CombinerDecorator, PersistenceDecorator]
+
+        # Iterate over decorators and update result accordingly
+        for i, decorator in enumerate(decorators):
+            decorator_idx = find_type_index(d, decorator)
+            if decorator_idx != -1:
+                result.append(decorator(d[decorator_idx].name))
+            else:
+                result.append(decorator("None"))
+                
+
+        return tuple(result)
+
+
+    def consistency_decorator(self, d) -> ConsistencyDecorator:
+        d = d[0]
+        return ConsistencyDecorator(d)
+    
+    def combiner_decorator(self, d) -> CombinerDecorator:
+        d = d[0]
+        return CombinerDecorator(d)
+    
+    def persistence_decorator(self, d) -> PersistenceDecorator:
+        d = d[0]
+        return PersistenceDecorator(d)
 
     def identifier(self, i) -> Identifier:
         i = i[0]

--- a/compiler/element/frontend/transformer.py
+++ b/compiler/element/frontend/transformer.py
@@ -1,7 +1,7 @@
 from lark import Transformer
 
-from compiler.element.node import *
 from compiler.element.frontend.util import *
+from compiler.element.node import *
 
 
 class IRTransformer(Transformer):
@@ -15,7 +15,11 @@ class IRTransformer(Transformer):
     def definition(self, d) -> Internal:
         return Internal(d)
 
-    def declaration(self, d) -> Tuple[Identifier, Type, ConsistencyDecorator, CombinerDecorator, PersistenceDecorator]:
+    def declaration(
+        self, d
+    ) -> Tuple[
+        Identifier, Type, ConsistencyDecorator, CombinerDecorator, PersistenceDecorator
+    ]:
         """
         Processes a list to create a declaration tuple consisting of an Identifier, Type, and optional decorators.
 
@@ -28,7 +32,7 @@ class IRTransformer(Transformer):
             A tuple containing the Identifier, Type, and instances of the optional decorators.
         """
         result = [d[-2], d[-1]]
-        
+
         # Define the list of decorator types
         decorators = [ConsistencyDecorator, CombinerDecorator, PersistenceDecorator]
 
@@ -39,19 +43,17 @@ class IRTransformer(Transformer):
                 result.append(decorator(d[decorator_idx].name))
             else:
                 result.append(decorator("None"))
-                
 
         return tuple(result)
-
 
     def consistency_decorator(self, d) -> ConsistencyDecorator:
         d = d[0]
         return ConsistencyDecorator(d)
-    
+
     def combiner_decorator(self, d) -> CombinerDecorator:
         d = d[0]
         return CombinerDecorator(d)
-    
+
     def persistence_decorator(self, d) -> PersistenceDecorator:
         d = d[0]
         return PersistenceDecorator(d)

--- a/compiler/element/frontend/util.py
+++ b/compiler/element/frontend/util.py
@@ -1,0 +1,20 @@
+def find_type_index(list, target_type):
+    """
+    Finds the index of the first occurrence of a specified type in a list.
+
+    Parameters:
+    list : list
+        The list to search through.
+    target_type : type
+        The type to find in the list.
+
+    Returns:
+    int
+        The index of the first occurrence of the specified type in the list.
+        Returns -1 if the type is not found in the list.
+    """
+    for i, item in enumerate(list):
+        # Check if the current item is an instance of the target_type
+        if isinstance(item, target_type):
+            return i  # Return the index of the first occurrence
+    return -1  # Return -1 if the type is not found

--- a/compiler/element/node.py
+++ b/compiler/element/node.py
@@ -33,7 +33,18 @@ class Program(Node):
 
 
 class Internal(Node):
-    def __init__(self, internal: List[Tuple[Identifier, Type, ConsistencyDecorator, CombinerDecorator, PersistenceDecorator]]):
+    def __init__(
+        self,
+        internal: List[
+            Tuple[
+                Identifier,
+                Type,
+                ConsistencyDecorator,
+                CombinerDecorator,
+                PersistenceDecorator,
+            ]
+        ],
+    ):
         self.internal = internal
 
 
@@ -78,8 +89,8 @@ class Expr(Node):
 class Identifier(Node):
     def __init__(self, name: str):
         self.name = name
-        
-        
+
+
 class ConsistencyDecorator(Node):
     def __init__(self, name: str):
         self.name = name

--- a/compiler/element/node.py
+++ b/compiler/element/node.py
@@ -33,7 +33,7 @@ class Program(Node):
 
 
 class Internal(Node):
-    def __init__(self, internal: List[Tuple[Identifier, Type]]):
+    def __init__(self, internal: List[Tuple[Identifier, Type, ConsistencyDecorator, CombinerDecorator, PersistenceDecorator]]):
         self.internal = internal
 
 
@@ -76,6 +76,21 @@ class Expr(Node):
 
 
 class Identifier(Node):
+    def __init__(self, name: str):
+        self.name = name
+        
+        
+class ConsistencyDecorator(Node):
+    def __init__(self, name: str):
+        self.name = name
+
+
+class CombinerDecorator(Node):
+    def __init__(self, name: str):
+        self.name = name
+
+
+class PersistenceDecorator(Node):
     def __init__(self, name: str):
         self.name = name
 

--- a/compiler/element_compiler_test.py
+++ b/compiler/element_compiler_test.py
@@ -28,6 +28,13 @@ if __name__ == "__main__":
         required=True,
         default="c",
     )
+    parser.add_argument(
+        "-r", "--proto", type=str, help="Filename of the Protobuf definition", required=True
+    )
+    
+    parser.add_argument(
+        "-m", "--method_name", type=str, help="Method Name (must be defined in proto)", required=True
+    )
     parser.add_argument("-b", "--backend", help="Backend Code Target", required=True)
     init_logging(True)
 
@@ -38,6 +45,8 @@ if __name__ == "__main__":
     verbose = args.verbose
     deploy = args.deploy
     placement = args.placement
+    proto_path = args.proto
+    method_name = args.method_name
     LOG.info(f"Elements: {elements}, Backend: {backend}")
     if placement == "c":
         placement = "client"
@@ -62,6 +71,8 @@ if __name__ == "__main__":
         str(COMPILER_ROOT) + "/generated/" + str(backend),
         backend,
         placement,
+        proto_path,
+        method_name,
         verbose,
     )
     end = datetime.datetime.now()

--- a/compiler/element_compiler_test.py
+++ b/compiler/element_compiler_test.py
@@ -37,12 +37,12 @@ if __name__ == "__main__":
     backend = args.backend
     verbose = args.verbose
     deploy = args.deploy
-    placement = args.placement.lower()
+    placement = args.placement
     LOG.info(f"Elements: {elements}, Backend: {backend}")
     if placement == "c":
-        placement = "Client"
+        placement = "client"
     elif placement == "s":
-        placement = "Server"
+        placement = "server"
     else:
         raise Exception("invalid Placement, c/s expected")
 

--- a/compiler/element_compiler_test.py
+++ b/compiler/element_compiler_test.py
@@ -29,11 +29,19 @@ if __name__ == "__main__":
         default="c",
     )
     parser.add_argument(
-        "-r", "--proto", type=str, help="Filename of the Protobuf definition", required=True
+        "-r",
+        "--proto",
+        type=str,
+        help="Filename of the Protobuf definition",
+        required=True,
     )
-    
+
     parser.add_argument(
-        "-m", "--method_name", type=str, help="Method Name (must be defined in proto)", required=True
+        "-m",
+        "--method_name",
+        type=str,
+        help="Method Name (must be defined in proto)",
+        required=True,
     )
     parser.add_argument("-b", "--backend", help="Backend Code Target", required=True)
     init_logging(True)

--- a/examples/element/statedummy.adn
+++ b/examples/element/statedummy.adn
@@ -1,0 +1,16 @@
+internal
+{
+    @consistency(strong) @combiner(sum) @persistence(ephemeral)
+	acl: Map<string, string>
+}
+
+fn init() {
+}
+
+fn req(rpc_req) {
+    send(rpc_req, NET);
+}
+
+fn resp(rpc_resp) {
+    send(rpc_resp, APP);	
+}


### PR DESCRIPTION
This PR does two things:
1) Extend the surface language to allow state annotations and extend the parser to handle it. Also, the property list now includes a "state" section"
2) Change the element compiler such that it can take proto and method names as input. This is necessary for our hotel reservation benchmark. (This PR adds this functionality for Envoy. mRPC is WIP)